### PR TITLE
Use specific boto3 requirements for this collection

### DIFF
--- a/plugins/doc_fragments/boto3.py
+++ b/plugins/doc_fragments/boto3.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2022,  Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+class ModuleDocFragment(object):
+
+    # Minimum requirements for the collection
+    DOCUMENTATION = r'''
+options: {}
+requirements:
+  - python >= 3.9
+  - boto3 >= 1.20.0
+  - botocore >= 1.23.0
+  - jsonpatch
+'''

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -19,6 +19,12 @@ plugins/module_utils/waiters.py metaclass-boilerplate!skip
 plugins/module_utils/waiters.py compile-2.6!skip
 plugins/module_utils/waiters.py import-2.6!skip
 plugins/module_utils/waiters.py import-2.7!skip
+plugins/doc_fragments/boto3.py future-import-boilerplate!skip
+plugins/doc_fragments/boto3.py metaclass-boilerplate!skip
+plugins/doc_fragments/boto3.py compile-2.6!skip
+plugins/doc_fragments/boto3.py import-2.6!skip
+plugins/doc_fragments/boto3.py import-2.7!skip
+plugins/modules/backup_backup_vault.py compile-2.7
 plugins/modules/backup_backup_vault.py compile-2.7!skip
 plugins/modules/backup_backup_vault.py compile-3.5!skip
 plugins/modules/backup_backup_vault.py import-2.7!skip

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -19,6 +19,11 @@ plugins/module_utils/waiters.py metaclass-boilerplate!skip
 plugins/module_utils/waiters.py compile-2.6!skip
 plugins/module_utils/waiters.py import-2.6!skip
 plugins/module_utils/waiters.py import-2.7!skip
+plugins/doc_fragments/boto3.py future-import-boilerplate!skip
+plugins/doc_fragments/boto3.py metaclass-boilerplate!skip
+plugins/doc_fragments/boto3.py compile-2.6!skip
+plugins/doc_fragments/boto3.py import-2.6!skip
+plugins/doc_fragments/boto3.py import-2.7!skip
 plugins/modules/backup_backup_vault.py compile-2.7!skip
 plugins/modules/backup_backup_vault.py compile-3.5!skip
 plugins/modules/backup_backup_vault.py import-2.7!skip

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -19,6 +19,11 @@ plugins/module_utils/waiters.py metaclass-boilerplate!skip
 plugins/module_utils/waiters.py compile-2.6!skip
 plugins/module_utils/waiters.py import-2.6!skip
 plugins/module_utils/waiters.py import-2.7!skip
+plugins/doc_fragments/boto3.py future-import-boilerplate!skip
+plugins/doc_fragments/boto3.py metaclass-boilerplate!skip
+plugins/doc_fragments/boto3.py compile-2.6!skip
+plugins/doc_fragments/boto3.py import-2.6!skip
+plugins/doc_fragments/boto3.py import-2.7!skip
 plugins/modules/backup_backup_vault.py compile-2.7!skip
 plugins/modules/backup_backup_vault.py compile-3.5!skip
 plugins/modules/backup_backup_vault.py import-2.7!skip


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1735
We can now set specific boto3 requirements for this collection and it is not necessary to be tied to the boto3 requirements of the amazon.aws collection.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

