### PR TITLE
Drop old ansible

### DIFF
--- a/changelogs/fragments/27-drop-old-ansible.yml
+++ b/changelogs/fragments/27-drop-old-ansible.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+- amazon.cloud collection - Support for ansible-core < 2.11 has been dropped (https://github.com/ansible-collections/amazon.cloud/pull/27).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,4 +1,4 @@
-requires_ansible: '>=2.9.10'
+requires_ansible: '>=2.11.0'
 action_groups:
   aws:
   - backup_backup_vault


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Drop old ansible. This change will be reflected in the next collection release thanks to this https://github.com/ansible-collections/amazon_cloud_code_generator/pull/51
This PR adds a changelog fragment also.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

