### PR TITLE
module_utils/waiters: adjust location of RetryingBotoClientWrapper

### DIFF
--- a/plugins/module_utils/waiters.py
+++ b/plugins/module_utils/waiters.py
@@ -12,9 +12,15 @@ try:
 except ImportError:
     pass  # caught by HAS_BOTO3
 
-from ansible_collections.amazon.aws.plugins.module_utils.modules import (
-    _RetryingBotoClientWrapper,
-)
+try:
+    # See: https://github.com/ansible-collections/amazon.aws/pull/1230
+    from ansible_collections.amazon.aws.plugins.module_utils.retries import (
+        RetryingBotoClientWrapper,
+    )
+except ImportError:
+    from ansible_collections.amazon.aws.plugins.module_utils.modules import (
+        _RetryingBotoClientWrapper,
+    )
 
 
 cloudcontrolapi_data = {
@@ -94,7 +100,7 @@ waiters_by_name = {
 
 
 def get_waiter(client, waiter_name):
-    if isinstance(client, _RetryingBotoClientWrapper):
+    if isinstance(client, RetryingBotoClientWrapper):
         return get_waiter(client.client, waiter_name)
     try:
         return waiters_by_name[(client.__class__.__name__, waiter_name)](client)


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1724
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1721
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1723

`RetryingBotoClientWrapper` should now be loaded from
`ansible_collections.amazon.aws.plugins.module_utils.retries`.

See: https://github.com/ansible-collections/amazon.aws/pull/1230
