### PR TITLE
tests: rely more on set_fact

### DIFF
--- a/tests/integration/targets/eks/tasks/cleanup.yml
+++ b/tests/integration/targets/eks/tasks/cleanup.yml
@@ -1,3 +1,4 @@
+- include_tasks: set_facts.yml
 - name: Delete IAM role
   community.aws.iam_role:
     name: "{{ _result_create_iam_role.role_name }}"

--- a/tests/integration/targets/eks/tasks/eks_cluster.yml
+++ b/tests/integration/targets/eks/tasks/eks_cluster.yml
@@ -1,3 +1,4 @@
+- include_tasks: set_facts.yml
 # Create a EKS Cluster to test Fargate Profile
 - name: Ensure IAM instance role exists
   community.aws.iam_role:

--- a/tests/integration/targets/eks/tasks/eks_fargate_profile.yml
+++ b/tests/integration/targets/eks/tasks/eks_fargate_profile.yml
@@ -1,3 +1,4 @@
+- include_tasks: set_facts.yml
 # Creating dependencies
 - name: Delete Fargate Profile b (if present)
   amazon.cloud.eks_fargate_profile:

--- a/tests/integration/targets/eks/tasks/set_facts.yml
+++ b/tests/integration/targets/eks/tasks/set_facts.yml
@@ -1,0 +1,55 @@
+- name: Set the cluster name
+  set_fact:
+    eks_cluster_name: "{{ _resource_prefix }}-cluster"
+
+- name: Define the tags
+  set_fact:
+    tags:
+      Foo: foo
+      bar: Bar
+
+- name: Define EKS facts
+  set_fact:
+    eks_fargate_profile_name_a: "{{ _resource_prefix }}-fp-a"
+    eks_fargate_profile_name_b: "{{ _resource_prefix }}-fp-b"
+    eks_subnets:
+      - zone: a
+        cidr: 10.0.1.0/24
+        type: private
+        tag: internal-elb
+      - zone: b
+        cidr: 10.0.2.0/24
+        type: public
+        tag: elb
+    eks_security_groups:
+      - name: "{{ eks_cluster_name }}-control-plane-sg"
+        description: "EKS Control Plane Security Group"
+        rules:
+          - group_name: "{{ eks_cluster_name }}-workers-sg"
+            group_desc: "EKS Worker Security Group"
+            ports: 443
+            proto: tcp
+        rules_egress:
+          - group_name: "{{ eks_cluster_name }}-workers-sg"
+            group_desc: "EKS Worker Security Group"
+            from_port: 1025
+            to_port: 65535
+            proto: tcp
+      - name: "{{ eks_cluster_name }}-workers-sg"
+        description: "EKS Worker Security Group"
+        rules:
+          - group_name: "{{ eks_cluster_name }}-workers-sg"
+            proto: tcp
+            from_port: 1
+            to_port: 65535
+          - group_name: "{{ eks_cluster_name }}-control-plane-sg"
+            ports: 10250
+            proto: tcp
+
+- name: Define selector
+  set_fact:
+    selectors:
+      - labels:
+        - key: "test"
+          value: "test"  
+        namespace: "fp-default"

--- a/tests/integration/targets/iam/tasks/main.yml
+++ b/tests/integration/targets/iam/tasks/main.yml
@@ -12,7 +12,8 @@
   block:
     - include_tasks: ./generate_certs.yml
 
-    - set_fact:
+    - name: Load the certificate data
+      set_fact:
         cert_a_data: '{{ lookup("file", path_cert_a) }}'
         cert_b_data: '{{ lookup("file", path_cert_b) }}'
         chain_cert_data: '{{ lookup("file", path_intermediate_cert) }}'

--- a/tests/integration/targets/s3/tasks/tagging.yml
+++ b/tests/integration/targets/s3/tasks/tagging.yml
@@ -1,38 +1,46 @@
 - name: Tests relating to setting tags
-  vars:
-    first_tags:
-      'Key with Spaces': Value with spaces
-      CamelCaseKey: CamelCaseValue
-      pascalCaseKey: pascalCaseValue
-      snake_case_key: snake_case_value
-    second_tags:
-      'New Key with Spaces': Value with spaces
-      NewCamelCaseKey: CamelCaseValue
-      newPascalCaseKey: pascalCaseValue
-      new_snake_case_key: snake_case_value
-    third_tags:
-      'Key with Spaces': Value with spaces
-      CamelCaseKey: CamelCaseValue
-      pascalCaseKey: pascalCaseValue
-      snake_case_key: snake_case_value
-      'New Key with Spaces': Updated Value with spaces
-    final_tags:
-      'Key with Spaces': Value with spaces
-      CamelCaseKey: CamelCaseValue
-      pascalCaseKey: pascalCaseValue
-      snake_case_key: snake_case_value
-      'New Key with Spaces': Updated Value with spaces
-      NewCamelCaseKey: CamelCaseValue
-      newPascalCaseKey: pascalCaseValue
-      new_snake_case_key: snake_case_value
-
   # Mandatory settings
   module_defaults:
     amazon.cloud.s3_bucket:
       bucket_name: "{{ output.result.identifier }}"
 
   block:
-    - name: test adding tags to amazon.cloud.s3_bucket (check mode)
+    - name: set first_tags fact
+      set_fact:
+        first_tags:
+          'Key with Spaces': Value with spaces
+          CamelCaseKey: CamelCaseValue
+          pascalCaseKey: pascalCaseValue
+          snake_case_key: snake_case_value
+    - name: set second_tags fact
+      set_fact:
+        second_tags:
+          'New Key with Spaces': Value with spaces
+          NewCamelCaseKey: CamelCaseValue
+          newPascalCaseKey: pascalCaseValue
+          new_snake_case_key: snake_case_value
+    - name: set third_tags fact
+      set_fact:
+        third_tags:
+          'Key with Spaces': Value with spaces
+          CamelCaseKey: CamelCaseValue
+          pascalCaseKey: pascalCaseValue
+          snake_case_key: snake_case_value
+          'New Key with Spaces': Updated Value with spaces
+    - name: set final_tags fact
+      set_fact:
+        final_tags:
+          'Key with Spaces': Value with spaces
+          CamelCaseKey: CamelCaseValue
+          pascalCaseKey: pascalCaseValue
+          snake_case_key: snake_case_value
+          'New Key with Spaces': Updated Value with spaces
+          NewCamelCaseKey: CamelCaseValue
+          newPascalCaseKey: pascalCaseValue
+          new_snake_case_key: snake_case_value
+
+
+    - name: _test adding tags to amazon.cloud.s3_bucket (check mode)
       amazon.cloud.s3_bucket:
         tags: '{{ first_tags }}'
         purge_tags: true


### PR DESCRIPTION
`gouttelette-refresh-examples` can include the set_fact tasks in the EXAMPLES block. This is not the case when the variables are defined in the `default/main.yml`.
