### PR TITLE
StatusMessage is not always defined in the progress_event

### DIFF
--- a/changelogs/fragments/avoid_KeyError_exception_during_wait.yaml
+++ b/changelogs/fragments/avoid_KeyError_exception_during_wait.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- "Address a situation where the creation of a resource with ``wait: true`` was causing an exception in case of timeout (https://github.com/ansible-collections/amazon.cloud/pull/60)."

--- a/plugins/module_utils/core.py
+++ b/plugins/module_utils/core.py
@@ -105,8 +105,10 @@ class CloudControlResource(object):
                 WaiterConfig=self._waiter_config,
             )
         except botocore.exceptions.WaiterError as e:
+            progress_event = e.last_response["ProgressEvent"]
+            message = progress_event.get("StatusMessage") or progress_event.get("OperationStatus")
             self.module.fail_json_aws(
-                e.last_response["ProgressEvent"]["StatusMessage"],
+                message,
                 msg="Resource request failed to reach successful state",
             )
         except (


### PR DESCRIPTION
With MemoryDB, `StatusMessage` is not always defined and this trigger an exception
within the existing exception handling block.

With this change we fallback on `OperationStatus` if `StatusMessage`
is missing. If none of them are available, we will get a `None` instead of
an exception.

According to the documentation the presence of these two keys is not guarantee.
They are both identified as optional (`Required: No`).

See: https://docs.aws.amazon.com/cloudcontrolapi/latest/APIReference/API_ProgressEvent.html
