### PR TITLE
Remove gouttelette related commands from tox.ini

### DIFF
--- a/changelogs/fragments/remove_gouttelette.yaml
+++ b/changelogs/fragments/remove_gouttelette.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+- "Remove references to gouttelette from tox.ini."

--- a/tox.ini
+++ b/tox.ini
@@ -18,18 +18,6 @@ commands =
 deps = git+https://github.com/ansible-network/collection_prep
 commands = collection_prep_add_docs -p .
 
-[testenv:refresh_modules]
-deps =
-  git+https://github.com/ansible-collections/gouttelette@main
-  git+https://github.com/ansible-collections/amazon_cloud_code_generator@main
-  {[testenv:black]deps}
-commands =
-  gouttelette-refresh-modules --target-dir . --collection amazon_cloud {posargs}
-  gouttelette-refresh-examples --target-dir .
-  black {toxinidir}/plugins {toxinidir}/tests
-allowlist_externals =
-  echo
-
 [testenv:linters]
 deps =
   {[testenv:black]deps}
@@ -77,9 +65,3 @@ ignore = E123,E125,E203,E402,E501,E741,F401,F811,F841,W503
 max-line-length = 160
 builtins = _
 exclude = .git,.tox,tests/unit/compat/
-
-[testenv:refresh-examples]
-deps =
-  git+https://github.com/ansible-collections/gouttelette
-commands =
-  gouttelette-refresh-examples --target-dir {toxinidir}


### PR DESCRIPTION
##### SUMMARY

The content generation of amazon.cloud collection is moved to [ansibe-community/content_builder. ](https://github.com/ansible-community/ansible.content_builder). [Gouttelette](https://github.com/ansible-collections/gouttelette), which was used earlier to do the same, will be archived soon. This PR removes references to gouttelette from amazon.cloud collection.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
