### PR TITLE
use GH_TOKEN as GITHUB_TOKEN when creating release branch

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -13,10 +13,12 @@ on:
         required: true
 
 jobs:
-  prepare:
+  create:
     permissions:
       contents: write
       pull-requests: write
     uses: ansible-network/github_actions/.github/workflows/release-branch.yml@main
     with:
       version: ${{ github.event.inputs.version }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/update-variables.yml
+++ b/.github/workflows/update-variables.yml
@@ -11,7 +11,15 @@ on:
       - main
       - 'stable-*'
   pull_request_target:
+    types:
+      - labeled
+      - unlabeled
+      - opened
+      - reopened
+      - synchronize
 
 jobs:
   update-variables:
     uses: ansible-network/github_actions/.github/workflows/update_aws_variables.yml@main
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Github actions cannot be triggered when default `GITHUB_TOKEN` is used to perform repository actions like (creating pull request, labeling pull requests or any other event which may trigger actions), in order to fix that we are using the Repository secrets `GH_TOKEN` as GITHUB token, same as the workflow `release-tag.yaml`