### PR TITLE
acl_name parameter should be camelcased as ACLName 

### DIFF
--- a/plugins/module_utils/core.py
+++ b/plugins/module_utils/core.py
@@ -227,9 +227,12 @@ class CloudControlResource(object):
 
         if isinstance(primary_identifier, list):
             for id in primary_identifier:
-                identifier[
-                    snake_to_camel(id, capitalize_first=True)
-                ] = self.module.params.get(id)
+                if id == "ACLName":
+                    identifier[id] = self.module.params.get("acl_name")
+                else:
+                    identifier[
+                        snake_to_camel(id, capitalize_first=True)
+                    ] = self.module.params.get(id)
             primary_identifier = json.dumps(identifier)
         elif isinstance(primary_identifier, dict):
             primary_identifier = json.dumps(primary_identifier)
@@ -262,16 +265,17 @@ class CloudControlResource(object):
         identifier: Dict = {}
 
         resource = None
-
         if self.module.params.get("identifier"):
             identifier = self.module.params.get("identifier")
         else:
             for id in primary_identifier:
-                identifier[
-                    snake_to_camel(id, capitalize_first=True)
-                ] = self.module.params.get(id)
+                if id == "ACLName":
+                    identifier[id] = self.module.params.get("acl_name")
+                else:
+                    identifier[
+                        snake_to_camel(id, capitalize_first=True)
+                    ] = self.module.params.get(id)
             identifier = json.dumps(identifier)
-
         try:
             resource = self.client.get_resource(
                 TypeName=type_name, Identifier=identifier, aws_retry=True
@@ -362,9 +366,12 @@ class CloudControlResource(object):
             identifier = self.module.params.get("identifier")
         else:
             for id in primary_identifier:
-                identifier[
-                    snake_to_camel(id, capitalize_first=True)
-                ] = self.module.params.get(id)
+                if id == "ACLName":
+                    identifier[id] = self.module.params.get("acl_name")
+                else:
+                    identifier[
+                        snake_to_camel(id, capitalize_first=True)
+                    ] = self.module.params.get(id)
             identifier = json.dumps(identifier)
 
         try:

--- a/plugins/modules/memorydb_acl.py
+++ b/plugins/modules/memorydb_acl.py
@@ -173,13 +173,13 @@ def main():
         params_to_set["ACLName"] = params_to_set.pop("AclName")
 
     # Ignore createOnlyProperties that can be set only during resource creation
-    create_only_params = ["acl_name"]
+    create_only_params = ["ACLName"]
 
     # Necessary to handle when module does not support all the states
     handlers = ["create", "read", "update", "delete", "list"]
 
     state = module.params.get("state")
-    identifier = ["acl_name"]
+    identifier = ["ACLName"]
 
     results = {"changed": False, "result": {}}
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

The naming convention for the acl_name key for the MemoryDB module is different from the convention followed for other keys.

Reference : https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-memorydb-cluster.html#cfn-memorydb-cluster-aclname


The changes to the module file should be added to the [template](https://github.com/ansible-community/ansible.content_builder/blob/main/roles/module_openapi_cloud/templates/module_directory/amazon_cloud/default_module.j2)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
