### PR TITLE
Release tag: use pull_request_target as trigger

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -6,7 +6,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
     branches:
@@ -14,9 +14,6 @@ on:
 
 jobs:
   tag:
-    permissions:
-      contents: write
-      pull-requests: write
     uses: ansible-network/github_actions/.github/workflows/release-tag.yml@main
     secrets:
       gh_token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
When using `pull_request` trigger, the workflow does not have access to repository secrets
Using `pull_request_target` allows sharing repository secrets (GH_TOKEN used to perform Github operation)
The `permissions` setting is not needed anymore as we are not using Github-generated token.