### PR TITLE
Backport PR107 to Release branch 0.4.0

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -6,7 +6,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
     branches:
@@ -14,9 +14,6 @@ on:
 
 jobs:
   tag:
-    permissions:
-      contents: write
-      pull-requests: write
     uses: ansible-network/github_actions/.github/workflows/release-tag.yml@main
     secrets:
       gh_token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
In order for the Release to be automatically tagged we need to backport this fix from the main branch into the Release branch