### PR TITLE
Exclude python 3.9 for milestone in unit/sanity test matrix

### DIFF
--- a/.github/workflows/unit_and_sanity.yml
+++ b/.github/workflows/unit_and_sanity.yml
@@ -79,6 +79,10 @@ jobs:
               "python-version": "3.8"
             },
             {
+              "ansible-version": "milestone",
+              "python-version": "3.9"
+            }
+            {
               "ansible-version": "devel",
               "python-version": "3.7"
             },
@@ -138,6 +142,10 @@ jobs:
             {
               "ansible-version": "milestone",
               "python-version": "3.8"
+            },
+            {
+              "ansible-version": "milestone",
+              "python-version": "3.9"
             },
             {
               "ansible-version": "devel",

--- a/changelogs/fragments/20230823-update-ci-unit-sanity-test-matrix.yaml
+++ b/changelogs/fragments/20230823-update-ci-unit-sanity-test-matrix.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Add milestone/python 3.9 to the sanity and unit test exclude matrix since 3.9 is no longer supported in milestone (https://github.com/ansible-collections/amazon.cloud/pull/117).


### PR DESCRIPTION
##### SUMMARY
The milestone and devel branches of ansible no longer support python 3.9. This PR adds milestone/python 3.9 to `matrix_exclude` in the unit and sanity test Github Actions workflow.

##### ISSUE TYPE
- Bugfix Pull Request