### PR TITLE
Integration tests update - iam_role migrated from community.aws to amazon.aws

### DIFF
--- a/changelogs/fragments/20230915_update_iam_role_from_integration.yml
+++ b/changelogs/fragments/20230915_update_iam_role_from_integration.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - Update integration tests target eks, iam_role has been migrated from community.aws to amazon.aws
+  - Update integration tests target eks, iam_role has been migrated from community.aws to amazon.aws (https://github.com/ansible-collections/amazon.cloud/pull/121).

--- a/changelogs/fragments/20230915_update_iam_role_from_integration.yml
+++ b/changelogs/fragments/20230915_update_iam_role_from_integration.yml
@@ -1,3 +1,3 @@
 ---
-minor_changes:
+trivial:
   - Update integration tests target eks, iam_role has been migrated from community.aws to amazon.aws (https://github.com/ansible-collections/amazon.cloud/pull/121).

--- a/changelogs/fragments/20230915_update_iam_role_from_integration.yml
+++ b/changelogs/fragments/20230915_update_iam_role_from_integration.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Update integration tests target eks, iam_role has been migrated from community.aws to amazon.aws

--- a/tests/integration/targets/eks/tasks/cleanup.yml
+++ b/tests/integration/targets/eks/tasks/cleanup.yml
@@ -1,12 +1,12 @@
 - include_tasks: set_facts.yml
 - name: Delete IAM role
-  community.aws.iam_role:
+  amazon.aws.iam_role:
     name: "{{ _result_create_iam_role.role_name }}"
     state: absent
   ignore_errors: true
 
 - name: Delete IAM role
-  community.aws.iam_role:
+  amazon.aws.iam_role:
     name: "{{ _result_create_iam_role_fp.role_name }}"
     state: absent
   ignore_errors: true

--- a/tests/integration/targets/eks/tasks/eks_cluster.yml
+++ b/tests/integration/targets/eks/tasks/eks_cluster.yml
@@ -1,7 +1,7 @@
 - include_tasks: set_facts.yml
 # Create a EKS Cluster to test Fargate Profile
 - name: Ensure IAM instance role exists
-  community.aws.iam_role:
+  amazon.aws.iam_role:
     name: "{{ _resource_prefix }}-cluster-role"
     assume_role_policy_document: "{{ lookup('file','eks_cluster-policy.json') }}"
     state: present

--- a/tests/integration/targets/eks/tasks/eks_fargate_profile.yml
+++ b/tests/integration/targets/eks/tasks/eks_fargate_profile.yml
@@ -27,7 +27,7 @@
   register: _result_delete_fp
 
 - name: Create IAM instance role
-  community.aws.iam_role:
+  amazon.aws.iam_role:
     name: "{{ _resource_prefix }}-fp-role"
     assume_role_policy_document: "{{ lookup('file', 'eks_fargate_profile-policy.json') }}"
     state: present


### PR DESCRIPTION
##### SUMMARY
Apply changes on integration tests target `eks`, as `iam_role` was migrated from `community.aws` to `amazon.aws`
Corresponding occurrences has been updated.

Note that https://github.com/ansible-collections/amazon.aws/pull/1757 has to be merged first

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request