### PR TITLE
update integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,8 +9,6 @@ on:
     types:
       - opened
       - reopened
-      - labeled
-      - unlabeled
       - synchronize
     branches:
       - main
@@ -18,52 +16,22 @@ on:
 
 jobs:
   integration:
-    
-    environment: protected # requires manual approval within GitHub Actions to proceed
-    
-    env:
-      source: "./source"
-      amazon: "./amazon"
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        ansible-version:
-          - milestone
-        python-version:
-          - "3.11"
-    name: "ansible-test-integration-py${{ matrix.python-version }}-${{ matrix.ansible-version }}"
+    env:
+      ansible_version: milestone
+      python_version: "3.12"
     steps:
-      - name: Checkout collection
-        uses: actions/checkout@v4
-
-      - name: checkout amazon.aws
-        uses: ansible-network/github_actions/.github/actions/checkout_dependency@main
-        with:
-          repository: ansible-collections/amazon.aws
-          path: ${{ env.amazon }}
-          ref: main
-
-      - name: Build and install collection
-        id: install-src
-        uses: ansible-network/github_actions/.github/actions/build_install_collection@main
-        with:
-          install_python_dependencies: true
-          source_path: ${{ env.source }}
-
-      - name: Build and install amazon.aws collection
-        id: install-amazon
-        uses: ansible-network/github_actions/.github/actions/build_install_collection@main
-        with:
-          install_python_dependencies: true
-          source_path: ${{ env.amazon }}
-
       - name: Create AWS/sts session credentials
         uses: ansible/ansible-test-auth@v1
 
       - name: Run integration tests
-        uses: ansible-network/github_actions/.github/actions/ansible_test_integration@main
+        uses: ansible-community/ansible-test-gh-action@d3a8ec7a59694e25e210fcd44738910149537f0e
         with:
-          collection_path: ${{ steps.install-src.outputs.collection_path }}
-          python_version: ${{ matrix.python-version }}
-          ansible_version: ${{ matrix.ansible-version }}
+          ansible-core-version: ${{ env.ansible_version }}
+          origin-python-version: ${{ env.python_version }}
+          testing-type: integration
+          test-deps: >-
+            git+https://github.com/ansible-collections/amazon.aws.git,main
+            git+https://github.com/ansible-collections/community.aws.git,main
+            community.crypto
+          pre-test-cmd: python -m pip install -r tests/integration/constraints.txt -r tests/integration/requirements.txt

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,13 +5,16 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened
       - labeled
       - unlabeled
       - synchronize
+    branches:
+      - main
+      - stable-*
 
 jobs:
   integration:
@@ -32,11 +35,7 @@ jobs:
     name: "ansible-test-integration-py${{ matrix.python-version }}-${{ matrix.ansible-version }}"
     steps:
       - name: Checkout collection
-        uses: actions/checkout@v3
-        with:
-          path: ${{ env.source }}
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: "0"
+        uses: actions/checkout@v4
 
       - name: checkout amazon.aws
         uses: ansible-network/github_actions/.github/actions/checkout_dependency@main
@@ -60,10 +59,7 @@ jobs:
           source_path: ${{ env.amazon }}
 
       - name: Create AWS/sts session credentials
-        uses: ansible-network/github_actions/.github/actions/ansible_aws_test_provider@main
-        with:
-          collection_path: ${{ steps.install-src.outputs.collection_path }}
-          ansible_core_ci_key: ${{ secrets.ANSIBLE_CORE_CI_KEY }}
+        uses: ansible/ansible-test-auth@v1
 
       - name: Run integration tests
         uses: ansible-network/github_actions/.github/actions/ansible_test_integration@main

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,4 +35,4 @@ jobs:
             git+https://github.com/ansible-collections/amazon.aws.git,main
             git+https://github.com/ansible-collections/community.aws.git,main
             community.crypto
-          pre-test-cmd: python -m pip install -r tests/integration/requirements.txt -r tests/integration/constraints.txt
+          pre-test-cmd: python -m pip install -r tests/integration/constraints.txt -r tests/integration/requirements.txt

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,6 +30,7 @@ jobs:
           ansible-core-version: ${{ env.ansible_version }}
           origin-python-version: ${{ env.python_version }}
           testing-type: integration
+          target-python-version: ${{ env.python_version }}
           test-deps: >-
             git+https://github.com/ansible-collections/amazon.aws.git,main
             git+https://github.com/ansible-collections/community.aws.git,main

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,4 +35,4 @@ jobs:
             git+https://github.com/ansible-collections/amazon.aws.git,main
             git+https://github.com/ansible-collections/community.aws.git,main
             community.crypto
-          pre-test-cmd: python -m pip install -r tests/integration/constraints.txt -r tests/integration/requirements.txt
+          pre-test-cmd: python -m pip install -r tests/integration/requirements.txt -r tests/integration/constraints.txt

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,7 +22,7 @@ jobs:
       python_version: "3.12"
     steps:
       - name: Create AWS/sts session credentials
-        uses: ansible/ansible-test-auth@v1
+        uses: ansible/ansible-test-auth@008750a5bf07124c3ab86d30d73d7319d7518f36
 
       - name: Run integration tests
         uses: ansible-community/ansible-test-gh-action@d3a8ec7a59694e25e210fcd44738910149537f0e

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,10 +22,10 @@ jobs:
       python_version: "3.12"
     steps:
       - name: Create AWS/sts session credentials
-        uses: ansible/ansible-test-auth@008750a5bf07124c3ab86d30d73d7319d7518f36
+        uses: ansible/ansible-test-auth@008750a5bf07124c3ab86d30d73d7319d7518f36  # v1.0.0, committed on Mar 13, 2026
 
       - name: Run integration tests
-        uses: ansible-community/ansible-test-gh-action@d3a8ec7a59694e25e210fcd44738910149537f0e
+        uses: ansible-community/ansible-test-gh-action@d3a8ec7a59694e25e210fcd44738910149537f0e  # v1.17.0, committed on Aug 6, 2025
         with:
           ansible-core-version: ${{ env.ansible_version }}
           origin-python-version: ${{ env.python_version }}

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -2,4 +2,6 @@
 boto3
 botocore
 
+jsonpatch
+
 virtualenv


### PR DESCRIPTION
Depends-On: #134 

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR updates the integration tests workflow with the follow changes

- Use the dedicated GHA to generate AWS credentials for testing and remove using of secret `ANSIBLE_CORE_CI_KEY`
- Update trigger from pull_request_target to pull_request since we no longer need to access to secrets
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`CI`
