### PR TITLE
Add SonarQube Cloud Test Coverage Info

### DIFF
--- a/.github/workflows/all_green_check.yml
+++ b/.github/workflows/all_green_check.yml
@@ -2,7 +2,7 @@
 name: all_green
 
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 on:  # yamllint disable-line rule:truthy
@@ -11,6 +11,10 @@ on:  # yamllint disable-line rule:truthy
       - opened
       - reopened
       - synchronize
+    branches:
+      - main
+      - 'stable-*'
+  push:
     branches:
       - main
       - 'stable-*'

--- a/.github/workflows/all_green_check.yml
+++ b/.github/workflows/all_green_check.yml
@@ -19,6 +19,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   linters:
+    if: github.event_name == 'pull_request'
     uses: ./.github/workflows/linters.yml  # use the callable linters job to run tests
   sanity:
     uses: ./.github/workflows/sanity.yml  # use the callable sanity job to run tests
@@ -27,48 +28,48 @@ jobs:
   coverage:
     name: Unit test coverage
     runs-on: ubuntu-latest
+    needs:
+      - sanity
+      - units
+    env:
+      ANSIBLE_CORE_REF: "stable-2.17"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
-      - name: Install ansible-core and dependencies
+      - name: Install Ansible (ansible-test)
         run: |
           python -m pip install --upgrade pip
-          pip install https://github.com/ansible/ansible/archive/stable-2.17.tar.gz --disable-pip-version-check
-          pip install coverage[toml]
+          python -m pip install "https://github.com/ansible/ansible/archive/${ANSIBLE_CORE_REF}.tar.gz"
 
       - name: Run unit tests with coverage
-        run: |
-          ansible-test units --venv --coverage --python 3.10 --requirements || true
+        run: ansible-test units --venv --coverage --python 3.10 --requirements
 
-      - name: Generate coverage XML
+      - name: Combine and emit coverage XML
         run: |
-          ansible-test coverage combine --venv --python 3.10 --requirements || true
+          ansible-test coverage combine --venv --python 3.10 --requirements
           ansible-test coverage xml --venv --python 3.10 --requirements
 
-      - name: Copy coverage file to repo root
+      - name: Prepare coverage.xml for SonarCloud
         run: |
-          COVERAGE_XML=$(find tests/output/reports -name "coverage*.xml" -type f 2>/dev/null | head -1)
-          if [[ -n "$COVERAGE_XML" ]]; then
-            cp "$COVERAGE_XML" coverage.xml
-            echo "Copied $COVERAGE_XML to coverage.xml"
-          else
-            echo "Warning: No coverage XML found, creating empty coverage.xml"
-            touch coverage.xml
-          fi
+          set -euo pipefail
+          mkdir -p "${GITHUB_WORKSPACE}"
+          xml=$(find tests/output/reports -maxdepth 1 -name '*.xml' ! -name '*powershell*' | head -1)
+          test -n "${xml}"
+          cp "${xml}" "${GITHUB_WORKSPACE}/coverage.xml"
+          # Strip workspace prefix so Sonar sees repo-relative paths (same idea as amazon.aws path rewrite)
+          sed -i "s#${GITHUB_WORKSPACE}/##g" "${GITHUB_WORKSPACE}/coverage.xml"
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:
           name: coverage
-          path: coverage.xml
+          path: ${{ github.workspace }}/coverage.xml
 
   all_green:
     if: ${{ always() }}
@@ -79,13 +80,45 @@ jobs:
       - coverage
     runs-on: ubuntu-latest
     steps:
-      - run: >-
-          python -c "assert set([
-          '${{ needs.linters.result }}',
-          '${{ needs.sanity.result }}',
-          '${{ needs.units.result }}',
-          '${{ needs.coverage.result }}'
-          ]) == {'success'}"
+      - run: |
+          python -c "
+          import sys
+
+          required = ['sanity', 'units', 'coverage']
+          if '${{ github.event_name }}' == 'pull_request':
+              required = ['linters', 'sanity', 'units', 'coverage']
+          results = {
+              'linters': '${{ needs.linters.result }}',
+              'sanity': '${{ needs.sanity.result }}',
+              'units': '${{ needs.units.result }}',
+              'coverage': '${{ needs.coverage.result }}',
+          }
+
+          for name in required:
+              if results[name] == 'failure':
+                  print(f'all_green: required job failed: {name} results={results}', file=sys.stderr)
+                  sys.exit(1)
+
+          # cancel-in-progress superseded this run; do not fail (newer run is authoritative)
+          if any(v == 'cancelled' for v in results.values()):
+              print(
+                  'all_green: one or more jobs cancelled (usually concurrency); skipping strict gate.',
+                  results,
+              )
+              sys.exit(0)
+
+          not_ok = [j for j in required if results[j] != 'success']
+          if not_ok:
+              print(f'all_green: required jobs not success: {not_ok} results={results}', file=sys.stderr)
+              sys.exit(1)
+
+          for job, status in results.items():
+              if job not in required and status not in ('success', 'skipped'):
+                  print(f'all_green: unexpected {job}={status} results={results}', file=sys.stderr)
+                  sys.exit(1)
+
+          print('all_green OK', results)
+          "
 
   sonarcloud:
     name: SonarCloud scan

--- a/.github/workflows/all_green_check.yml
+++ b/.github/workflows/all_green_check.yml
@@ -24,17 +24,80 @@ jobs:
     uses: ./.github/workflows/sanity.yml  # use the callable sanity job to run tests
   units:
     uses: ./.github/workflows/units.yml  # use the callable units job to run tests
+  coverage:
+    name: Unit test coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install ansible-core and dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install https://github.com/ansible/ansible/archive/stable-2.17.tar.gz --disable-pip-version-check
+          pip install coverage[toml]
+
+      - name: Run unit tests with coverage
+        run: |
+          ansible-test units --venv --coverage --python 3.10 --requirements || true
+
+      - name: Generate coverage XML
+        run: |
+          ansible-test coverage combine --venv --python 3.10 --requirements || true
+          ansible-test coverage xml --venv --python 3.10 --requirements
+
+      - name: Copy coverage file to repo root
+        run: |
+          COVERAGE_XML=$(find tests/output/reports -name "coverage*.xml" -type f 2>/dev/null | head -1)
+          if [[ -n "$COVERAGE_XML" ]]; then
+            cp "$COVERAGE_XML" coverage.xml
+            echo "Copied $COVERAGE_XML to coverage.xml"
+          else
+            echo "Warning: No coverage XML found, creating empty coverage.xml"
+            touch coverage.xml
+          fi
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage.xml
+
   all_green:
     if: ${{ always() }}
     needs:
       - linters
       - sanity
       - units
+      - coverage
     runs-on: ubuntu-latest
     steps:
       - run: >-
           python -c "assert set([
           '${{ needs.linters.result }}',
           '${{ needs.sanity.result }}',
-          '${{ needs.units.result }}'
+          '${{ needs.units.result }}',
+          '${{ needs.coverage.result }}'
           ]) == {'success'}"
+
+  sonarcloud:
+    name: SonarCloud scan
+    needs:
+      - all_green
+      - coverage
+    if: >-
+      ${{ needs.all_green.result == 'success'
+      && secrets.ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT != ''
+      && (github.event_name == 'push'
+      || (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name == github.repository)) }}
+    uses: ./.github/workflows/sonarcloud.yml
+    secrets:
+      ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT: ${{ secrets.ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT }}

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -19,7 +19,7 @@ jobs:
       init-lenient: false
       init-fail-on-error: true
       extra-collections: |
-        'git+https://github.com/ansible-collections/amazon.aws.git,main'
+        git+https://github.com/ansible-collections/amazon.aws.git,main
       intersphinx-links: |
         amazon_aws:https://ansible-collections.github.io/amazon.aws/branch/main/
         community_aws:https://ansible-collections.github.io/community.aws/branch/main/
@@ -35,7 +35,7 @@ jobs:
       init-lenient: true
       init-fail-on-error: false
       extra-collections: |
-        'git+https://github.com/ansible-collections/amazon.aws.git,main'
+        git+https://github.com/ansible-collections/amazon.aws.git,main
       intersphinx-links: |
         amazon_aws:https://ansible-collections.github.io/amazon.aws/branch/main/
         community_aws:https://ansible-collections.github.io/community.aws/branch/main/

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # Amazon Cloud Collection for Ansible
+
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ansible-collections_amazon.cloud&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=ansible-collections_amazon.cloud)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=ansible-collections_amazon.cloud&metric=coverage)](https://sonarcloud.io/summary/new_code?id=ansible-collections_amazon.cloud)
+
 The AWS Cloud Control Collection is an experimental alpha collection of generated modules using the Cloud Control API for interacting with AWS Services.
 
 ## Description
 
 AWS Cloud Control Collection's work is being made available for research purposes on the Cloud Control API and community feedback on the user experience of API generated module like these. Therefore, this content is not intended for production in its current state.
 It provides the automation capabilities needed to optimize cloud operations, ensuring efficient, reliable, and secure management of AWS resources.
+
+For information about code quality analysis and static analysis results, see the [SonarCloud project overview](https://sonarcloud.io/project/overview?id=ansible-collections_amazon.cloud).
 
 ## Included content
 <!--start collection content-->

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ansible-collections_amazon.cloud&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=ansible-collections_amazon.cloud)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=ansible-collections_amazon.cloud&metric=coverage)](https://sonarcloud.io/summary/new_code?id=ansible-collections_amazon.cloud)
+[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=ansible-collections_amazon.cloud&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=ansible-collections_amazon.cloud)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=ansible-collections_amazon.cloud&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=ansible-collections_amazon.cloud)
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=ansible-collections_amazon.cloud&metric=bugs)](https://sonarcloud.io/summary/new_code?id=ansible-collections_amazon.cloud)
+[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=ansible-collections_amazon.cloud&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=ansible-collections_amazon.cloud)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=ansible-collections_amazon.cloud&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=ansible-collections_amazon.cloud)
 
 The AWS Cloud Control Collection is an experimental alpha collection of generated modules using the Cloud Control API for interacting with AWS Services.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Amazon Cloud Collection for Ansible
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ansible-collections_amazon.cloud&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=ansible-collections_amazon.cloud)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=ansible-collections_amazon.cloud&metric=coverage)](https://sonarcloud.io/summary/new_code?id=ansible-collections_amazon.cloud)
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=ansible-collections_amazon.cloud&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=ansible-collections_amazon.cloud)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=ansible-collections_amazon.cloud&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=ansible-collections_amazon.cloud)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=ansible-collections_amazon.cloud&metric=bugs)](https://sonarcloud.io/summary/new_code?id=ansible-collections_amazon.cloud)

--- a/SONARCLOUD.md
+++ b/SONARCLOUD.md
@@ -2,7 +2,7 @@
 
 SonarQube Cloud (SonarCloud) is a Software-as-a-Service (SaaS) code analysis tool that helps maintain code quality by identifying issues related to maintainability, reliability, and security.
 
-The amazon.cloud collection uses SonarQube Cloud to analyze the main branch and pull requests, and (once coverage CI is wired) to track unit test coverage and quality gate compliance.
+The amazon.cloud collection uses SonarQube Cloud to analyze the main branch and pull requests, and to track unit test coverage and quality gate compliance.
 
 ## Core concepts
 
@@ -20,7 +20,7 @@ The collection uses **CI-based analysis** with GitHub Actions:
 
 - The SonarScanner runs inside the CI build.
 - Configuration is controlled in the repository (`sonar-project.properties` and `.github/workflows/sonarcloud.yml`).
-- **Code coverage** will be produced by a dedicated coverage job in `all_green` and passed to the scanner via a `coverage` artifact (follow-up CI work; see [Coverage integration](#coverage-integration-planned) below).
+- **Code coverage** is produced by a dedicated coverage job in `all_green` and passed to the scanner via a `coverage` artifact (see [Coverage integration](#coverage-integration) below).
 
 Automatic analysis is not used because it does not support code coverage and has limited branch support.
 
@@ -80,15 +80,15 @@ GitHub **does not** expose org/repository secrets to workflows triggered by pull
 
 Fork PRs may skip Sonar until changes are merged or a maintainer runs analysis from a trusted branch. See [Using secrets in GitHub Actions](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions) and [Approving workflow runs from forks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/approving-workflow-runs-from-public-forks).
 
-## Coverage integration (planned)
+## Coverage integration
 
-This repository's **first** SonarCloud PR adds `sonar-project.properties`, the reusable `sonarcloud.yml`, and this document. A **follow-up** PR will:
+Coverage integration is now complete:
 
-1. Add a **coverage** job to `.github/workflows/all_green_check.yml` that produces Cobertura XML and uploads it as artifact **`coverage`**.
-2. Extend the **`all_green`** gate to depend on **coverage**.
-3. Add a **`sonarcloud`** job that calls `./.github/workflows/sonarcloud.yml` with explicit `secrets:` for `ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT` (see org template `all_green-caller.sonarcloud-job.yml.template` in the ansible-collection-sdlc module).
+1. A **coverage** job in `.github/workflows/all_green_check.yml` produces Cobertura XML and uploads it as artifact **`coverage`**.
+2. The **`all_green`** gate depends on **coverage** completion.
+3. A **`sonarcloud`** job calls `./.github/workflows/sonarcloud.yml` with explicit `secrets:` for `ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT`.
 
-Until that lands, CI will not run SonarCloud scans automatically; you can still validate configuration with the SonarScanner CLI locally (below).
+CI now runs SonarCloud scans automatically on pull requests and pushes to `main` and `stable-*` branches. You can also validate configuration with the SonarScanner CLI locally (see [Debugging SonarCloud issues](#debugging-sonarcloud-issues) below).
 
 ## Summary
 
@@ -96,16 +96,16 @@ Until that lands, CI will not run SonarCloud scans automatically; you can still 
 |-----------|------|--------|
 | Sonar project settings | `sonar-project.properties` | Present |
 | Reusable scanner workflow | `.github/workflows/sonarcloud.yml` | Present (`workflow_call` only) |
-| `all_green` coverage + Sonar caller | `.github/workflows/all_green_check.yml` | Planned (follow-up PR) |
+| `all_green` coverage + Sonar caller | `.github/workflows/all_green_check.yml` | Complete |
 
-| Workflow | File | Trigger (when fully wired) | Purpose |
-|----------|------|----------------------------|---------|
+| Workflow | File | Trigger | Purpose |
+|----------|------|---------|---------|
 | `all_green` | `.github/workflows/all_green_check.yml` | `pull_request`, push to `main` / `stable-*` | Linters, sanity, units, coverage; gate on success |
 | SonarCloud | `.github/workflows/sonarcloud.yml` | `workflow_call` from `all_green` | Download coverage artifact and run SonarScanner |
 
 ## Debugging SonarCloud issues
 
-If analysis fails or coverage is missing after coverage CI is enabled:
+If analysis fails or coverage is missing:
 
 1. **Check `all_green`**: Ensure the workflow (including the **coverage** job) succeeded for the same commit.
 2. **Check artifact**: In the SonarCloud run, confirm the download and "Set coverage report paths" steps found at least one `coverage*.xml` and set `COVERAGE_PATHS`.
@@ -117,7 +117,7 @@ If analysis fails or coverage is missing after coverage CI is enabled:
 
    Fix any errors reported at the end of the output.
 
-*Note:* Misconfigured `sonar-project.properties` may not fail the main PR checks until the Sonar job is wired and required. Use the SonarCloud project page and local `sonar-scanner` runs to verify settings.
+*Note:* Use the SonarCloud project page and local `sonar-scanner` runs to verify settings if analysis results are unexpected.
 
 ## Prerequisites (org admins)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is part 2 of https://redhat.atlassian.net/browse/ACA-5021
Continued from https://github.com/ansible-collections/amazon.cloud/pull/135

- implement coverage job in all_green_check.yml
- all_green completes only when linters, sanity, units, and coverage all succeed
- Add SonarQube coverage buttons to README

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
Assisted-by: Claude Sonnet 4.5 [noreply@anthropic.com](mailto:noreply@anthropic.com)
https://github.com/ansible-community/ai-forge/pull/9